### PR TITLE
Added support for minimum and maximum line height attributes

### DIFF
--- a/ParserJSON.py
+++ b/ParserJSON.py
@@ -93,6 +93,10 @@ def main(argv):
                 label.textColor = value['textColor']
             if "lineSpacing" in value:
                 label.lineSpacing = value['lineSpacing']
+            if "minimumLineHeight" in value:
+                label.minimumLineHeight = value['minimumLineHeight']
+            if "maximumLineHeight" in value:
+                label.maximumLineHeight = value['maximumLineHeight']
             if label.attributes:
                 swiftgenerator.buildAttributesForObjects([label])
             swiftgenerator.buildStyleFunctions([label])
@@ -115,6 +119,10 @@ def main(argv):
                 textView.textColor = value['textColor']
             if "lineSpacing" in value:
                 textView.lineSpacing = value['lineSpacing']
+            if "minimumLineHeight" in value:
+                label.minimumLineHeight = value['minimumLineHeight']
+            if "maximumLineHeight" in value:
+                label.maximumLineHeight = value['maximumLineHeight']
             if textView.attributes:
                 swiftgenerator.buildAttributesForObjects([textView])
             swiftgenerator.buildStyleFunctions([textView])

--- a/SwiftGenerator.py
+++ b/SwiftGenerator.py
@@ -196,12 +196,16 @@ class SwiftGenerator:
             attributes = object.attributes
             self.write("func attributesFor" + object.name + "() -> " + self.attributeDictionary + " { ")
             self.enter()
-            if object.textAlignment or attributes.lineSpacing:
+            if object.textAlignment or attributes.lineSpacing or attributes.minimumLineHeight or attributes.maximumLineHeight:
                 set([self.write("let style = NSMutableParagraphStyle()")]),self.newline()
                 if object.textAlignment:
                     set([self.write("style.alignment = NSTextAlignment." + object.textAlignment)]),self.newline()
                 if attributes.lineSpacing:
                     set([self.write("style.lineSpacing = " + str(attributes.lineSpacing))]),self.newline()
+                if attributes.minimumLineHeight:
+                    set([self.write("style.minimumLineHeight = " + str(attributes.minimumLineHeight))]), self.newline()
+                if attributes.maximumLineHeight :
+                    set([self.write("style.maximumLineHeight = " + str(attributes.maximumLineHeight))]), self.newline()
             self.write("let attributes = [ ")
             self.indent(),self.newline()
             if isinstance(attributes, UIObjects.TextAttributes):
@@ -210,7 +214,7 @@ class SwiftGenerator:
                 if attributes.tracking:
                     characterSpacing = attributes.fontStyle.size * attributes.tracking / 1000
                     set([self.write("NSKernAttributeName: " + str(characterSpacing))]),self.addSeperator(attributes),self.newline()
-                if object.textAlignment or attributes.lineSpacing:
+                if object.textAlignment or attributes.lineSpacing or attributes.minimumLineHeight or attributes.maximumLineHeight:
                     set([self.write("NSParagraphStyleAttributeName: style")]),self.addSeperator(attributes),self.newline()
                 if attributes.ligature: set([self.write("NSLigatureAttributeName: " + str(attributes.ligature))]),self.addSeperator(attributes),self.newline()
             self.outdent()

--- a/UIObjects.py
+++ b/UIObjects.py
@@ -182,6 +182,16 @@ class TextAttributes:
         if "lineSpacing" in self.properties:
             return (self.properties['lineSpacing'])
 
+    @property
+    def minimumLineHeight(self):
+        if "minimumLineHeight" in self.properties:
+            return (self.properties['minimumLineHeight'])
+
+    @property
+    def maximumLineHeight(self):
+        if "maximumLineHeight" in self.properties:
+            return (self.properties['maximumLineHeight'])
+
 class Button(View, FontStyle):
     def __init__(self, name, properties = {}):
         self.name = name


### PR DESCRIPTION
This is adding support for `minimumLineHeight` an `maximumLineHeight` paragraph style attributes according to this documentation: https://developer.apple.com/library/ios/documentation/Cocoa/Reference/ApplicationKit/Classes/NSParagraphStyle_Class/index.html#//apple_ref/occ/cl/NSParagraphStyle

The problem that this solves is issue with presenting emojis which, in some fonts, need higher line height then the default:
### Before Update (top row cut off)

<img width="321" alt="screen shot 2016-04-30 at 7 47 52 pm" src="https://cloud.githubusercontent.com/assets/15822274/14941738/db2271c0-0f74-11e6-8f36-697d60052812.png">
### After Update

<img width="239" alt="screen shot 2016-04-30 at 7 48 04 pm" src="https://cloud.githubusercontent.com/assets/15822274/14941740/e91387ce-0f74-11e6-92ca-aedf4a6ea41b.png">

There are still more attributes that should be added, but we can leave that for later. 
